### PR TITLE
feat(shell): add talosctl.zsh script for credential management

### DIFF
--- a/hosts/shared/programs/shell/default.nix
+++ b/hosts/shared/programs/shell/default.nix
@@ -4,9 +4,29 @@
     initExtra = ''
       # Source MEGA completion
       # source /Applications/MEGAcmd.app/Contents/MacOS/megacmd_completion.sh
+
+      # Source additional scripts
+      if [ -d $HOME/.zsh_scripts ]; then
+        for file in $HOME/.zsh_scripts_local/*.zsh; do
+          source $file
+        done
+      fi
+
     '';
 
     # Aliases
-    shellAliases = {};
+    shellAliases = {
+      talos = "talosctl";
+    };
   };
+
+  home = {
+    file = {
+      ".zsh_scripts_local/" = {
+        recursive = true;
+        source = ./zsh_scripts;
+      };
+    };
+  };
+
 }

--- a/hosts/shared/programs/shell/zsh_scripts/talosctl.zsh
+++ b/hosts/shared/programs/shell/zsh_scripts/talosctl.zsh
@@ -1,0 +1,23 @@
+talos_context() {
+  #!/bin/bash
+
+  # Fetch all items from the vault "JHC" in the category "API Credential" with names containing "talos"
+  items=$(op item list --vault "JHC" --categories "API Credential" --format json | jq -r '.[] | select(.title | contains("talos")) | .id + " " + .title')
+
+  # Use fzf to select an item
+  selected_item=$(echo "$items" | fzf --delimiter " " --with-nth 2.. | awk '{print $1}')
+
+  # Fetch the credential field content from the selected item
+  file_content=$(op item get "$selected_item" --vault "JHC" --format json | jq -r '.fields[] | select(.label == "text") | .value')
+
+  # Write the file content to /tmp/talosconfig
+  echo "$file_content" > /tmp/talosconfig
+
+  # Export the talosconfig
+  export TALOSCONFIG=/tmp/talosconfig
+
+  # Run talosctl kubeconfig with the selected entry
+  selected_title=$(echo "$items" | grep "$selected_item" | awk '{print $2}')
+  talosctl kubeconfig --force ~/.kube/"$selected_title"
+  talosctl dashboard
+}


### PR DESCRIPTION
Implemented a new utility script to handle Talos context setup, including fetching credentials using 1Password and configuring Talosctl.