### PR TITLE
Revert "chore: move to vesktop"

### DIFF
--- a/hosts/darwin/system.nix
+++ b/hosts/darwin/system.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ pkgs, vars, ... }:
 
 ###################################################################################
 #
@@ -23,7 +23,7 @@
           "/System/Applications/Calendar.app"
           "/Applications/WhatsApp.app"
           "/System/Applications/Messages.app"
-          "${pkgs.vesktop}/Applications/Vesktop.app"
+          "/Users/${vars.user.name}/Applications/Home Manager Apps/Discord.app"
           "${pkgs.obsidian}/Applications/Obsidian.app"
           "/Applications/Things3.app"
           "/Applications/Linear.app"


### PR DESCRIPTION
This reverts commit 83e88a79ac36314dabac3e34a099bcb77f0fdc98.
